### PR TITLE
fix BLAS operations

### DIFF
--- a/src/auxiliary/blas.jl
+++ b/src/auxiliary/blas.jl
@@ -11,19 +11,19 @@ dot(n :: Int, x :: Vector{T}, y :: Vector{T}) where T <: BLAS.BlasReal = BLAS.do
 dot(n :: Int, x :: AbstractVector{T}, y :: AbstractVector{T}) where T <: Number = dot(x, y)
 
 axpy!(n :: Int, t :: T, d :: Vector{T}, x :: Vector{T}) where T <: BLAS.BlasReal = BLAS.axpy!(n, t, d, 1, x, 1)
-axpy!(n :: Int, t :: T, d :: AbstractVector{T}, x :: AbstractVector{T}) where T <: Number = (x .+= t * d)
+axpy!(n :: Int, t :: T, d :: AbstractVector{T}, x :: AbstractVector{T}) where T <: Number = (x .+= t .* d)
 
 axpby!(n :: Int, t :: T, d :: Vector{T}, s :: T, x :: Vector{T}) where T <: BLAS.BlasReal = BLAS.axpby!(n, t, d, 1, s, x, 1)
-axpby!(n :: Int, t :: T, d :: AbstractVector{T}, s :: T, x :: AbstractVector{T}) where T <: Number = (x .= t * d + s * x)
+axpby!(n :: Int, t :: T, d :: AbstractVector{T}, s :: T, x :: AbstractVector{T}) where T <: Number = (x .= t .* d .+ s .* x)
 
 scal!(n :: Int, t :: T, x :: Vector{T}) where T <: BLAS.BlasReal = BLAS.scal!(n, t, x, 1)
-scal!(n :: Int, t :: T, x :: AbstractVector{T}) where T <: Number = (x *= t)
+scal!(n :: Int, t :: T, x :: AbstractVector{T}) where T <: Number = (x .*= t)
 
 function copyaxpy!(n :: Int, t :: T, d :: Vector{T}, x :: Vector{T}, xt :: Vector{T}) where T <: BLAS.BlasReal
   BLAS.blascopy!(n, x, 1, xt, 1)
   BLAS.axpy!(n, t, d, 1, xt, 1)
 end
 function copyaxpy!(n :: Int, t :: T, d :: AbstractVector{T}, x :: AbstractVector{T}, xt :: AbstractVector{T}) where T <: Number
-  xt .= x + t * d
+  xt .= x .+ t .* d
 end
 


### PR DESCRIPTION
Each operation needs to be vectorized. Otherwise, we allocate tempory vectors.
It's why the macro `@.` is useful, we are sure to don't miss one.