### PR TITLE
Better log

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,8 @@ Pages = ["api.md"]
 active
 breakpoints
 compute_Hs_slope_qs!
+log_header
+log_row
 project!
 project_step!
 ```

--- a/src/SolverTools.jl
+++ b/src/SolverTools.jl
@@ -12,6 +12,7 @@ using DataFrames
 # Auxiliary.
 include("auxiliary/blas.jl")
 include("auxiliary/bounds.jl")
+include("auxiliary/logger.jl")
 include("stats/stats.jl")
 
 # Algorithmic components.
@@ -19,7 +20,7 @@ include("linesearch/linesearch.jl")
 include("trust-region/trust-region.jl")
 
 # Utilities.
-include("bmark/run_solver.jl")
 include("bmark/bmark_solvers.jl")
+include("bmark/run_solver.jl")
 
 end

--- a/src/auxiliary/logger.jl
+++ b/src/auxiliary/logger.jl
@@ -1,0 +1,73 @@
+export log_header, log_row
+
+const formats = Dict{DataType, String}(Signed => "%5d",
+                                       AbstractFloat => "%8.1e",
+                                       AbstractString => "%15s",
+                                       Symbol => "%15s",
+                                       Missing => "%15s"
+                                      )
+
+const default_headers = Dict{Symbol, String}(:name => "Name",
+                                             :elapsed_time => "Time",
+                                             :objective => "f(x)",
+                                             :dual_feas => "Dual",
+                                             :primal_feas => "Primal")
+
+for (typ, fmt) in formats
+  @eval begin
+    row_formatter(x :: $typ) = @sprintf($fmt, x)
+  end
+
+  hdr_fmt_foo = Symbol("header_formatter_$typ")
+  len = match(r"\%([0-9]*)", fmt)[1]
+  fmt2 = "%$(len)s"
+  @eval begin
+    $hdr_fmt_foo(x) = @sprintf($fmt2, x)
+    header_formatter(x :: Union{Symbol,String}, :: Type{<:$typ}) = $hdr_fmt_foo(x)
+  end
+end
+
+"""
+    log_header(colnames, coltypes)
+
+Creates a header using the names in `colnames` formatted according to the types in `coltypes`.
+Uses internal formatting specification given by `SolverTools.formats` and default header
+translation given by `SolverTools.default_headers`.
+
+Input:
+- `colnames::Vector{Symbol}`: Column names.
+- `coltypes::Vector{DataType}`: Column types.
+
+Keyword argument:
+- `hdr_override::Dict{Symbol,String}`: Overrides the default headers.
+
+See also [`log_row`](@ref).
+"""
+function log_header(colnames :: AbstractVector{Symbol}, coltypes :: AbstractVector{DataType};
+                    hdr_override :: Dict{Symbol,String} = Dict{Symbol,String}(),
+                   )
+  out = ""
+  for (name, typ) in zip(colnames, coltypes)
+    x = if haskey(hdr_override, name)
+      hdr_override[name]
+    elseif haskey(default_headers, name)
+      default_headers[name]
+    else
+      string(name)
+    end
+    out *= header_formatter(x, typ) * "  "
+  end
+  return out
+end
+
+"""
+    log_row(vals)
+
+Creates a table row from the values on `vals` according to their types. Pass the names
+and types of `vals` to [`log_header`](@ref) for a logging table. Uses internal formatting
+specification given by `SolverTools.formats`.
+"""
+function log_row(vals)
+  string_cols = (row_formatter(val) for val in vals)
+  return join(string_cols, "  ")
+end

--- a/src/bmark/run_solver.jl
+++ b/src/bmark/run_solver.jl
@@ -24,7 +24,7 @@ Apply a solver to a set of problems.
 function solve_problems(solver :: Function, problems :: Any;
                         solver_logger :: AbstractLogger=NullLogger(),
                         skipif :: Function=x->false,
-                        infocols :: Vector{Symbol} = [:name, :nvar, :ncon, :status, :elapsed_time, :objective, :dual_feas, :primal_feas],
+                        colstats :: Vector{Symbol} = [:name, :nvar, :ncon, :status, :elapsed_time, :objective, :dual_feas, :primal_feas],
                         info_hdr_override :: Dict{Symbol,String} = Dict{Symbol,String}(),
                         prune :: Bool=true, kwargs...)
   nprobs = length(problems)
@@ -60,8 +60,8 @@ function solve_problems(solver :: Function, problems :: Any;
             push!(specific, k)
           end
 
-          col_idx = indexin(infocols, names)
-          @info log_header(infocols, types[col_idx], hdr_override=info_hdr_override)
+          col_idx = indexin(colstats, names)
+          @info log_header(colstats, types[col_idx], hdr_override=info_hdr_override)
 
           first_problem = false
         end

--- a/src/bmark/run_solver.jl
+++ b/src/bmark/run_solver.jl
@@ -32,8 +32,8 @@ function solve_problems(solver :: Function, problems :: Any;
   f_counters = collect(fieldnames(Counters))
   fnls_counters = collect(fieldnames(NLSCounters))[2:end] # Excludes :counters
   ncounters = length(f_counters) + length(fnls_counters)
-  types = [Int; String;   Int;   Int;   Int;  Symbol;    Float64;       Float64;   Int;    Float64; fill(Int, ncounters); String]
-  names = [:id;  :name; :nvar; :ncon; :nequ; :status; :objective; :elapsed_time; :iter; :dual_feas; f_counters; fnls_counters; :extrainfo]
+  types = [Int; String;   Int;   Int;   Int;  Symbol;    Float64;       Float64;   Int;    Float64;      Float64; fill(Int, ncounters); String]
+  names = [:id;  :name; :nvar; :ncon; :nequ; :status; :objective; :elapsed_time; :iter; :dual_feas; :primal_feas; f_counters; fnls_counters; :extrainfo]
   stats = DataFrame(types, names, 0)
 
   specific = Symbol[]
@@ -46,7 +46,7 @@ function solve_problems(solver :: Function, problems :: Any;
     nequ = problem isa AbstractNLSModel ? problem.nls_meta.nequ : 0
     problem_info = [id; problem.meta.name; problem.meta.nvar; problem.meta.ncon; nequ]
     if skipif(problem)
-      prune || push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf;
+      prune || push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf; Inf;
                              fill(0, ncounters); "skipped"; fill(missing, length(specific))])
       finalize(problem)
       continue
@@ -62,12 +62,12 @@ function solve_problems(solver :: Function, problems :: Any;
         end
         first_problem = false
       end
-      push!(stats, [problem_info; s.status; s.objective; s.elapsed_time; s.iter; s.dual_feas;
+      push!(stats, [problem_info; s.status; s.objective; s.elapsed_time; s.iter; s.dual_feas; s.primal_feas;
                     [getfield(s.counters.counters, f) for f in f_counters];
                     [getfield(s.counters, f) for f in fnls_counters]; "";
                     [s.solver_specific[k] for k in specific]])
     catch e
-      push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf;
+      push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf; Inf;
                     fill(0, ncounters); string(e); fill(missing, length(specific))])
     finally
       finalize(problem)

--- a/test/dummy_solver.jl
+++ b/test/dummy_solver.jl
@@ -1,0 +1,50 @@
+function dummy_solver(nlp :: AbstractNLPModel;
+                      x :: AbstractVector = nlp.meta.x0,
+                      atol :: Real = sqrt(eps(eltype(x))),
+                      rtol :: Real = sqrt(eps(eltype(x))),
+                      max_eval :: Int = 1000,
+                      max_time :: Float64 = 30.0,
+                     )
+
+  start_time = time()
+  elapsed_time = 0.0
+
+  nvar, ncon = nlp.meta.nvar, nlp.meta.ncon
+  T = eltype(x)
+
+  fx = obj(nlp, x)
+  cx = ncon > 0 ? cons(nlp, x) : zeros(T)
+  α = one(T)
+
+  iter = 0
+  @info log_header([:iter, :f, :c, :t],
+             [Int, T, T, Float64])
+  @info log_row(Any[iter, fx, norm(cx), elapsed_time])
+  tired = neval_obj(nlp) + neval_cons(nlp) > max_eval || elapsed_time > max_time
+
+  while !tired
+    xt = x + α * convert.(T, randn(nvar))
+    ft = obj(nlp, xt)
+    ct = ncon > 0 ? cons(nlp, xt) : zeros(T)
+    if ft < fx && norm(ct) ≤ norm(cx)
+      x .= xt
+      fx = ft
+      cx .= ct
+    else
+      α = 9α / 10
+    end
+
+    iter += 1
+    elapsed_time = time() - start_time
+    tired = neval_obj(nlp) + neval_cons(nlp) > max_eval || elapsed_time > max_time
+    @info log_row(Any[iter, fx, norm(cx), elapsed_time])
+  end
+
+  return GenericExecutionStats(:unknown, nlp,
+                               objective=fx,
+                               dual_feas=norm(grad(nlp, x)),
+                               primal_feas=norm(cx),
+                               elapsed_time=elapsed_time,
+                               solution=x,
+                              )
+end

--- a/test/dummy_solver.jl
+++ b/test/dummy_solver.jl
@@ -17,8 +17,7 @@ function dummy_solver(nlp :: AbstractNLPModel;
   α = one(T)
 
   iter = 0
-  @info log_header([:iter, :f, :c, :t],
-             [Int, T, T, Float64])
+  @info log_header([:iter, :f, :c, :t], [Int, T, T, Float64])
   @info log_row(Any[iter, fx, norm(cx), elapsed_time])
   tired = neval_obj(nlp) + neval_cons(nlp) > max_eval || elapsed_time > max_time
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using SolverTools
 using NLPModels
 
 # stdlib
-using LinearAlgebra, Test
+using LinearAlgebra, Logging, Test
+
+include("dummy_solver.jl")
 
 include("test_stats.jl")
+include("test_logging.jl")

--- a/test/test_logging.jl
+++ b/test/test_logging.jl
@@ -3,8 +3,7 @@ function test_logging()
   push!(nlps, ADNLPModel(x -> dot(x, x), ones(2), c=x->[sum(x)-1], lcon=[0.0], ucon=[0.0], name="linquad"))
 
   @info "Testing logger"
-  log_header([:col_float, :col_int, :col_symbol, :col_string],
-             [Float64, Int, Symbol, String])
+  log_header([:col_float, :col_int, :col_symbol, :col_string], [Float64, Int, Symbol, String])
   log_row([1.0, 1, :one, "one"])
 
   with_logger(ConsoleLogger()) do
@@ -17,7 +16,7 @@ function test_logging()
     reset!.(nlps)
 
     @info "Testing logger with specific columns on `solve_problems`"
-    solve_problems(dummy_solver, nlps, infocols=[:name, :nvar, :elapsed_time, :objective, :dual_feas])
+    solve_problems(dummy_solver, nlps, colstats=[:name, :nvar, :elapsed_time, :objective, :dual_feas])
     reset!.(nlps)
 
     @info "Testing logger with hdr_override on `solve_problems`"

--- a/test/test_logging.jl
+++ b/test/test_logging.jl
@@ -1,0 +1,30 @@
+function test_logging()
+  nlps = [ADNLPModel(x -> sum(x.^k), ones(2k), name="Sum of power $k") for k = 2:4]
+  push!(nlps, ADNLPModel(x -> dot(x, x), ones(2), c=x->[sum(x)-1], lcon=[0.0], ucon=[0.0], name="linquad"))
+
+  @info "Testing logger"
+  log_header([:col_float, :col_int, :col_symbol, :col_string],
+             [Float64, Int, Symbol, String])
+  log_row([1.0, 1, :one, "one"])
+
+  with_logger(ConsoleLogger()) do
+    @info "Testing dummy solver with logger"
+    dummy_solver(nlps[1], max_eval=20)
+    reset!.(nlps)
+
+    @info "Testing simple logger on `solve_problems`"
+    solve_problems(dummy_solver, nlps)
+    reset!.(nlps)
+
+    @info "Testing logger with specific columns on `solve_problems`"
+    solve_problems(dummy_solver, nlps, infocols=[:name, :nvar, :elapsed_time, :objective, :dual_feas])
+    reset!.(nlps)
+
+    @info "Testing logger with hdr_override on `solve_problems`"
+    hdr_override = Dict(:dual_feas => "‖∇L(x)‖", :primal_feas => "‖c(x)‖")
+    solve_problems(dummy_solver, nlps, info_hdr_override=hdr_override)
+    reset!.(nlps)
+  end
+end
+
+test_logging()


### PR DESCRIPTION
Closes #75 

- Implements `log_header` and `log_row`, to be used instead of `@info @sprintf ...`;
- `log_header` and `log_row` are also being used by `solve_problems`;
- Creates a `dummy_solver` to test the iteration printing;
- docs updated accordingly;
- Small corrections and modifications for consistency.