### PR TITLE
Preallocate on LineModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,7 @@ julia = "^1.3.0"
 [extras]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADNLPModels", "Logging", "NLPModels", "Test"]
+test = ["ADNLPModels", "Logging", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using ADNLPModels, NLPModels
 using LinearAlgebra, Logging, Test
 
 include("dummy_solver.jl")
+include("simple_model.jl")
 
 include("test_auxiliary.jl")
 include("test_linesearch.jl")

--- a/test/simple_model.jl
+++ b/test/simple_model.jl
@@ -1,0 +1,35 @@
+mutable struct SimpleModel{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
+  counters :: Counters
+end
+
+SimpleModel(n :: Int) = SimpleModel(NLPModelMeta(n, x0=ones(n)), Counters())
+
+function NLPModels.obj(nlp::SimpleModel, x::AbstractVector)
+  increment!(nlp, :neval_obj)
+  sum(xi ^ 4 for xi in x) / 12
+end
+
+function NLPModels.grad!(nlp::SimpleModel, x::AbstractVector, g::AbstractVector)
+  increment!(nlp, :neval_grad)
+  @. g = x ^ 3 / 3
+  g
+end
+
+function NLPModels.objgrad!(nlp::SimpleModel, x::AbstractVector, g::AbstractVector)
+  increment!(nlp, :neval_obj)
+  increment!(nlp, :neval_grad)
+  @. g = x ^ 3 / 3
+  return sum(xi ^4 for xi in x) / 12, g
+end
+
+function NLPModels.hprod!(nlp::SimpleModel, x::AbstractVector{T}, v::AbstractVector, Hv::AbstractVector; obj_weight::T = one(T)) where T
+  increment!(nlp, :neval_hprod)
+  @. Hv = obj_weight * x ^ 2 * v
+  Hv
+end
+
+function NLPModels.hess(nlp::SimpleModel, x::AbstractVector{T}; obj_weight::T = one(T)) where T
+  increment!(nlp, :neval_hprod)
+  return obj_weight .* diagm(0 => x .^ 2)
+end


### PR DESCRIPTION
Stores `xt` inside LineModel to prevent allocations.

WIP because I can't predict the allocations of `armijo_wolfe` yet.
Testing manually with [this script](https://gist.github.com/abelsiqueira/6948e55e609cacd24509054f59069adb) gives a different result.