### PR TITLE
Parametric NLPModelMeta

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 LinearOperators = "0.4.0, 0.5.0, 0.6.0, 0.7.0, 1.0"
-NLPModels = "0.14"
+NLPModels = "0.15"
 julia = "^1.3.0"
 
 [extras]

--- a/src/linesearch/line_model.jl
+++ b/src/linesearch/line_model.jl
@@ -12,16 +12,16 @@ represents the function ϕ : R → R defined by
 
     ϕ(t) := f(x + td).
 """
-mutable struct LineModel <: AbstractNLPModel
-  meta::NLPModelMeta
+mutable struct LineModel{T, S} <: AbstractNLPModel{T, S}
+  meta::NLPModelMeta{T, S}
   counters::Counters
-  nlp::AbstractNLPModel
+  nlp::AbstractNLPModel{T, S}
   x::AbstractVector
   d::AbstractVector
 end
 
-function LineModel(nlp::AbstractNLPModel, x::AbstractVector, d::AbstractVector)
-  meta = NLPModelMeta(1, x0 = zeros(eltype(x), 1), name = "LineModel to $(nlp.meta.name))")
+function LineModel(nlp::AbstractNLPModel{T, S}, x::AbstractVector, d::AbstractVector) where {T, S}
+  meta = NLPModelMeta{T, S}(1, x0 = zeros(T, 1), name = "LineModel to $(nlp.meta.name))")
   return LineModel(meta, Counters(), nlp, x, d)
 end
 

--- a/src/linesearch/line_model.jl
+++ b/src/linesearch/line_model.jl
@@ -16,11 +16,11 @@ mutable struct LineModel{T, S} <: AbstractNLPModel{T, S}
   meta::NLPModelMeta{T, S}
   counters::Counters
   nlp::AbstractNLPModel{T, S}
-  x::AbstractVector
-  d::AbstractVector
+  x::S
+  d::S
 end
 
-function LineModel(nlp::AbstractNLPModel{T, S}, x::AbstractVector, d::AbstractVector) where {T, S}
+function LineModel(nlp::AbstractNLPModel{T, S}, x::S, d::S) where {T, S}
   meta = NLPModelMeta{T, S}(1, x0 = zeros(T, 1), name = "LineModel to $(nlp.meta.name))")
   return LineModel(meta, Counters(), nlp, x, d)
 end


### PR DESCRIPTION
Follows [NLPModels.jl PR #353](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/353) with parametric meta.

Should be merged after [NLPModelsTest.jl PR #11](https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/11) and [ADNLPModel.jl PR]().