### PR TITLE
Add `DCISolver` in breakage

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         pkg: [
+          "JuliaSmoothOptimizers/DCISolver.jl",
           "JuliaSmoothOptimizers/JSOSolvers.jl",
           "JuliaSmoothOptimizers/Percival.jl"
         ]


### PR DESCRIPTION
`DCISolver.jl` uses `aredpred!`, see [L.29](https://github.com/JuliaSmoothOptimizers/DCISolver.jl/blob/c08f8b96d42cc2879e7a4e19a19ab50898b2745c/src/dci_tangent.jl#L29).