### PR TITLE
Line-search solver for Armijo-Goldstein conditions

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,3 +5,4 @@ SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
 Documenter = "~0.26"
+ADNLPModels = "0.7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
 Documenter = "~0.26"

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -75,7 +75,7 @@ function armijo_goldstein(
   else
   end
 
-  # Bissect inside bracket [t_low, t_up]
+  # Bisect inside bracket [t_low, t_up]
   armijo_fail = ht > h₀ + τ₀ * t * slope
   goldstein_fail = ht < h₀ + τ₁ * t * slope
   while (armijo_fail && (nbk < bk_max)) && nbk || (goldstein_fail && (nbW < bW_max))

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -71,7 +71,7 @@ function armijo_goldstein(
   slope::T;
   t::T = one(T),
   τ₀::T = T(eps(T)^(1/4)),
-  τ₁::T = min(T(1)-eps(T),T(0.9999)),
+  τ₁::T = T(1)-eps(T),
   γ₀::T = T(1 / 2),
   γ₁::T = T(2),
   bk_max::Int = 10,
@@ -112,8 +112,7 @@ function armijo_goldstein(
   end
 
   # Bisect inside bracket [t_low, t_up]
-  
-  while (armijo_fail && (nbk < bk_max)) && nbk || (goldstein_fail && (nbG < bG_max))
+  while (armijo_fail && (nbk < bk_max))|| (goldstein_fail && (nbG < bG_max))
     t = (t_up - t_low) / 2
     if armijo_fail
       t_up = t

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -1,0 +1,98 @@
+export armijo_goldstein
+
+"""
+    t, ht, nbk, nbW = armijo_goldstein(h, h₀, slope)
+
+Performs a line search from `x` along the direction `d` as defined by the
+`LineModel` ``h(t) = f(x + t d)``, where
+`h₀ = h(0) = f(x)`, `slope = h'(0) = ∇f(x)ᵀd`.
+The steplength is chosen trying to satisfy the Armijo and Goldstein conditions. The Armijo condition is
+```math
+h(t) ≤ h₀ + τ₀ t h'(0)
+```
+and the Goldstein condition is
+```math
+h(t) ≥ h₀ + τ₁ t h'(0).
+```
+
+The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bissection algorithm to find such a point.
+
+The output is the following:
+- t: the step length;
+- ht: the model value at `t`, i.e., `f(x + t * d)`;
+- nbk: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., number of backtracks;
+- nbW: the number of times the steplength was increased to satisfy the Goldstein condition.
+
+The following keyword arguments can be provided:
+- `t`: starting steplength (default `1`);
+- `τ₀`: slope factor in the Armijo condition (default `max(1e-4, √ϵₘ)`);
+- `τ₁`: slope factor in the Goldstein condition. It should satisfy `τ₁ > τ₀` (default `0.9999`);
+- `bk_max`: maximum number of backtracks (default `10`);
+- `bW_max`: maximum number of increases (default `10`);
+- `verbose`: whether to print information (default `false`).
+"""
+function armijo_goldstein(
+  h::LineModel,
+  h₀::T,
+  slope::T;
+  t::T = one(T),
+  τ₀::T = max(T(1.0e-4), sqrt(eps(T))),
+  τ₁::T = T(0.9999),
+  bk_max::Int = 10,
+  bW_max::Int = 10,
+  verbose::Bool = false,
+) where {T <: AbstractFloat}
+  t_low = T(0)
+  t_up = t
+  # Perform improved Armijo linesearch.
+  nbk = 0
+  nbW = 0
+
+  ht = obj(h, t)
+
+  armijo_fail = ht > h₀ + τ₀ * t * slope
+  goldstein_fail = ht < h₀ + τ₁ * t * slope
+  # Backtracking: set t_up so that Armijo condition is satisfied
+  if armijo_fail
+    while armijo_fail && (nbk < bk_max)
+      t_up = t
+      t /= 2
+      ht = obj(h, t)
+      nbk += 1
+      armijo_fail = ht > h₀ + τ₀ * t * slope
+    end
+    t_low = t
+    #Look ahead: set t_low so that Goldstein condition is satisfied
+  elseif goldstein_fail
+    while goldstein_fail && (nbW < bW_max)
+      t_low = t
+      t *= 2
+      ht = obj(h, t)
+      nbW += 1
+      goldstein_fail = ht < h₀ + τ₁ * t * slope
+    end
+    t_up = t
+  else
+  end
+
+  # Bissect inside bracket [t_low, t_up]
+  armijo_fail = ht > h₀ + τ₀ * t * slope
+  goldstein_fail = ht < h₀ + τ₁ * t * slope
+  while (armijo_fail && (nbk < bk_max)) && nbk || (goldstein_fail && (nbW < bW_max))
+    t = 1 / 2 * (t_up - t_low)
+    if armijo_fail
+      t_up = t
+      nbk += 1
+    elseif goldstein_fail
+      t_low = t
+      nbW += 1
+    else
+    end
+    armijo_fail = ht > h₀ + τ₀ * t * slope
+    goldstein_fail = ht < h₀ + τ₁ * t * slope
+  end
+
+  verbose && @printf("  %4d %4d\n", nbk, nbW)
+
+  return (t, ht, nbk, nbW)
+end

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -36,8 +36,8 @@ function armijo_goldstein(
   h₀::T,
   slope::T;
   t::T = one(T),
-  τ₀::T = max(T(1.0e-4), sqrt(eps(T))),
-  τ₁::T = T(0.9999),
+  τ₀::T = T(eps(T)^(1/4)),
+  τ₁::T = min(prevfloat(T(1)),T(0.9999)),
   bk_max::Int = 10,
   bW_max::Int = 10,
   verbose::Bool = false,

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -72,7 +72,7 @@ function armijo_goldstein(
   h₀::T,
   slope::T;
   t::T = one(T),
-  τ₀::T = T(eps(T)^(1/4)),
+  τ₀::T = T(eps(T)^(1 / 4)),
   τ₁::T = T(1)-eps(T),
   γ₀::T = T(1 / 2),
   γ₁::T = T(2),

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -15,8 +15,6 @@ and the Goldstein condition is
 h(t) ≥ h₀ + τ₁ t h'(0).
 ```
 
-The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bisection algorithm to find such a point.
-
 # Arguments
 
 - `h::LineModel{T, S, M}`: 1-D model along the search direction `d`, ``h(t) = f(x + t d)``
@@ -39,6 +37,31 @@ The keyword arguments may include
 - `nbk::Int`: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., number of backtracks;
 - `nbG::Int`: the number of times the steplength was increased to satisfy the Goldstein condition.
 
+
+# References
+This implementation follows the description given in
+
+    C. Cartis, P.R. Sampaio, P.L. Toint,
+    Worst-case evaluation complexity of non-monotone gradient-related algorithms for unconstrained optimization.
+    Optimization 64(5), 1349–1361 (2015).
+    DOI: 10.1080/02331934.2013.869809
+    
+  The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bisection algorithm to find such a point.
+  The method is implemented with M=0 (see reference), i.e., only the current value of the objective is required to satisfied to Armijo and Goldstein conditions. 
+
+  # Examples
+
+```jldoctest; output = false
+using SolverTools, ADNLPModels
+nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(2))
+lm = LineModel(nlp, nlp.meta.x0, -ones(2))
+
+t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+
+# output
+
+(1.0, 0.0, 0, 0)
+```
 
 """
 function armijo_goldstein(

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -29,7 +29,7 @@ with `0 < τ₀ < τ₁ < 1`.
 - `γ₀::T = T(1 / 2)`: backtracking step length mutliplicative factor (0 < γ₀ <1)
 - `γ₁::T = T(2)`: look-ahead step length mutliplicative factor (γ₁ > 1)
 - `bk_max`: maximum number of backtracks (default: `10`);
-- `bG_max`: maximum number of increases (default `10`);
+- `bG_max`: maximum number of increases (default: `10`);
 - `verbose`: whether to print information (default: `false`).
 
 # Outputs

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -3,10 +3,9 @@ export armijo_goldstein
 """
     t, ht, nbk, nbG = armijo_goldstein(h, h₀, slope)
 
-Performs a line search from `x` along the direction `d` as defined by the
-`LineModel` ``h(t) = f(x + t d)``, where
-`h₀ = h(0) = f(x)`, `slope = h'(0) = ∇f(x)ᵀd`.
-The steplength is chosen trying to satisfy the Armijo and Goldstein conditions. The Armijo condition is
+Perform a line search from `x` along the direction `d` as defined by the `LineModel` `h(t) = f(x + t d)`, where `h₀ = h(0) = f(x)`, and `slope = h'(0) = ∇f(x)ᵀd`.
+The steplength is chosen to satisfy the Armijo-Goldstein conditions.
+The Armijo condition is
 ```math
 h(t) ≤ h₀ + τ₀ t h'(0)
 ```
@@ -14,35 +13,38 @@ and the Goldstein condition is
 ```math
 h(t) ≥ h₀ + τ₁ t h'(0).
 ```
-with `1 > τ₁ > τ₀ > 0`.
+with `0 < τ₀ < τ₁ < 1`.
 
 # Arguments
 
 - `h::LineModel{T, S, M}`: 1-D model along the search direction `d`, ``h(t) = f(x + t d)``
-- `h₀::T`: value of `h` at `t=0`
-- `slope`: dot product of the gradient and the search direction, ``∇f(x_k)ᵀd``
-The keyword arguments may include
-- `t::T = one(T)`: starting steplength (default `1`);
-- `τ₀::T = T(eps(T)^(1/4))`: slope factor in the Armijo condition. It should satisfy `1 > τ₁ > τ₀ > 0`;
-- `τ₁::T = min(T(1)-eps(T),T(0.9999))`: slope factor in the Goldstein condition. It should satisfy `1 > τ₁ > τ₀ > 0`;
-- `γ₀::T = T(1 / 2)`: backtracking step length mutliplicative factor (0<γ₀<1)
-- `γ₁::T = T(2)`: look-aheqd step length mutliplicative factor (1<γ₁)
-- `bk_max`: maximum number of backtracks (default `10`);
+- `h₀::T`: value of `h` at `t = 0`
+- `slope`: dot product of the gradient and the search direction, ``∇f(x)ᵀd``
+
+# Keyword arguments
+
+- `t::T = one(T)`: initial steplength (default: `1`);
+- `τ₀::T = T(eps(T)^(1/4))`: slope factor in the Armijo condition. It should satisfy `0 < τ₀ < τ₁ < 1 `;
+- `τ₁::T = min(T(1)-eps(T), T(0.9999))`: slope factor in the Goldstein condition. It should satisfy `0 < τ₀ < τ₁ < 1 `;
+- `γ₀::T = T(1 / 2)`: backtracking step length mutliplicative factor (0 < γ₀ <1)
+- `γ₁::T = T(2)`: look-ahead step length mutliplicative factor (γ₁ > 1)
+- `bk_max`: maximum number of backtracks (default: `10`);
 - `bG_max`: maximum number of increases (default `10`);
-- `verbose`: whether to print information (default `false`).
+- `verbose`: whether to print information (default: `false`).
 
 # Outputs
 
 - `t::T`: the step length;
 - `ht::T`: the model value at `t`, i.e., `f(x + t * d)`;
-- `nbk::Int`: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., number of backtracks;
+- `nbk::Int`: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., the number of backtracks;
 - `nbG::Int`: the number of times the steplength was increased to satisfy the Goldstein condition.
 
 
 # References
+
 This implementation follows the description given in
 
-    C. Cartis, P.R. Sampaio, P.L. Toint,
+    C. Cartis, P. R. Sampaio, Ph. L. Toint,
     Worst-case evaluation complexity of non-monotone gradient-related algorithms for unconstrained optimization.
     Optimization 64(5), 1349–1361 (2015).
     DOI: 10.1080/02331934.2013.869809

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -79,7 +79,7 @@ function armijo_goldstein(
   armijo_fail = ht > h₀ + τ₀ * t * slope
   goldstein_fail = ht < h₀ + τ₁ * t * slope
   while (armijo_fail && (nbk < bk_max)) && nbk || (goldstein_fail && (nbW < bW_max))
-    t = 1 / 2 * (t_up - t_low)
+    t = (t_up - t_low) / 2
     if armijo_fail
       t_up = t
       nbk += 1

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -14,6 +14,7 @@ and the Goldstein condition is
 ```math
 h(t) ≥ h₀ + τ₁ t h'(0).
 ```
+with `1 > τ₁ > τ₀ > 0`.
 
 # Arguments
 
@@ -22,8 +23,8 @@ h(t) ≥ h₀ + τ₁ t h'(0).
 - `slope`: dot product of the gradient and the search direction, ``∇f(x_k)ᵀd``
 The keyword arguments may include
 - `t::T = one(T)`: starting steplength (default `1`);
-- `τ₀::T = T(eps(T)^(1/4))`: slope factor in the Armijo condition (default `max(1e-4, √ϵₘ)`);
-- `τ₁::T = min(prevfloat(T(1)),T(0.9999))`: slope factor in the Goldstein condition. It should satisfy `τ₁ > τ₀` (default `0.9999`);
+- `τ₀::T = T(eps(T)^(1/4))`: slope factor in the Armijo condition. It should satisfy `1 > τ₁ > τ₀ > 0`;
+- `τ₁::T = min(T(1)-eps(T),T(0.9999))`: slope factor in the Goldstein condition. It should satisfy `1 > τ₁ > τ₀ > 0`;
 - `γ₀::T = T(1 / 2)`: backtracking step length mutliplicative factor (0<γ₀<1)
 - `γ₁::T = T(2)`: look-aheqd step length mutliplicative factor (1<γ₁)
 - `bk_max`: maximum number of backtracks (default `10`);
@@ -47,7 +48,7 @@ This implementation follows the description given in
     DOI: 10.1080/02331934.2013.869809
     
   The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bisection algorithm to find such a point.
-  The method is implemented with M=0 (see reference), i.e., only the current value of the objective is required to satisfied to Armijo and Goldstein conditions. 
+  The method is implemented with M=0 (see reference), i.e., Armijo and Goldstein conditions are satisfied only for the current value of the objective `h₀`. 
 
   # Examples
 
@@ -70,7 +71,7 @@ function armijo_goldstein(
   slope::T;
   t::T = one(T),
   τ₀::T = T(eps(T)^(1/4)),
-  τ₁::T = min(prevfloat(T(1)),T(0.9999)),
+  τ₁::T = min(T(1)-eps(T),T(0.9999)),
   γ₀::T = T(1 / 2),
   γ₁::T = T(2),
   bk_max::Int = 10,
@@ -108,7 +109,6 @@ function armijo_goldstein(
     end
     armijo_fail = !armijo_condition(h₀, ht, τ₀, t, slope)
     t_up = t
-  else
   end
 
   # Bisect inside bracket [t_low, t_up]
@@ -121,7 +121,6 @@ function armijo_goldstein(
     elseif goldstein_fail
       t_low = t
       nbG += 1
-    else
     end
     ht = obj(h, t)
     armijo_fail = !armijo_condition(h₀, ht, τ₀, t, slope)

--- a/src/linesearch/armijo_goldstein.jl
+++ b/src/linesearch/armijo_goldstein.jl
@@ -15,15 +15,14 @@ and the Goldstein condition is
 h(t) ≥ h₀ + τ₁ t h'(0).
 ```
 
-The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bissection algorithm to find such a point.
+The method initializes an interval ` [t_low,t_up]` guaranteed to contain a point satifying both Armijo and Goldstein conditions, and then uses a bisection algorithm to find such a point.
 
-The output is the following:
-- t: the step length;
-- ht: the model value at `t`, i.e., `f(x + t * d)`;
-- nbk: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., number of backtracks;
-- nbG: the number of times the steplength was increased to satisfy the Goldstein condition.
+# Arguments
 
-The following keyword arguments can be provided:
+- `h::LineModel{T, S, M}`: 1-D model along the search direction `d`, ``h(t) = f(x + t d)``
+- `h₀::T`: value of `h` at `t=0`
+- `slope`: dot product of the gradient and the search direction, ``∇f(x_k)ᵀd``
+The keyword arguments may include
 - `t::T = one(T)`: starting steplength (default `1`);
 - `τ₀::T = T(eps(T)^(1/4))`: slope factor in the Armijo condition (default `max(1e-4, √ϵₘ)`);
 - `τ₁::T = min(prevfloat(T(1)),T(0.9999))`: slope factor in the Goldstein condition. It should satisfy `τ₁ > τ₀` (default `0.9999`);
@@ -32,6 +31,15 @@ The following keyword arguments can be provided:
 - `bk_max`: maximum number of backtracks (default `10`);
 - `bG_max`: maximum number of increases (default `10`);
 - `verbose`: whether to print information (default `false`).
+
+# Outputs
+
+- `t::T`: the step length;
+- `ht::T`: the model value at `t`, i.e., `f(x + t * d)`;
+- `nbk::Int`: the number of times the steplength was decreased to satisfy the Armijo condition, i.e., number of backtracks;
+- `nbG::Int`: the number of times the steplength was increased to satisfy the Goldstein condition.
+
+
 """
 function armijo_goldstein(
   h::LineModel,

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -1,2 +1,3 @@
 include("line_model.jl")
 include("armijo_wolfe.jl")
+include("armijo_goldstein.jl")

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -88,10 +88,16 @@
 
     nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, zeros(T,2))
     lm = LineModel(nlp, nlp.meta.x0, T.([1.7; 3.2]))
-    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(2.))
-    @test t == 1.
-    @test nbk == 1
-    @test nbG == 0
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(1.), τ₀ = T(0.1), τ₁ = T(0.2))
+    @test t < 1.
+    @test nbk == 4
+    @test nbG == 10
+
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(.001), τ₀ = T(0.1), τ₁ = T(0.2))
+    @test t < 1.
+    @test nbk == 2
+    @test nbG == 10
+
   end
 
   if VERSION ≥ v"1.6"

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -62,29 +62,30 @@
   end
 
   @testset "Armijo-Goldstein" begin
-    T = Float32
-    nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(T,2))
-    lm = LineModel(nlp, nlp.meta.x0, -ones(T,2))
-    g = zeros(T,2)
+    nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(2))
+    lm = LineModel(nlp, nlp.meta.x0, -ones(2))
+    g = zeros(2)
 
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)))
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
     @test ft == 0.0
     @test nbk == 0
     @test nbW == 0
 
-    redirect!(lm, nlp.meta.x0, -ones(T,2) / 2)
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)))
+    redirect!(lm, nlp.meta.x0, -ones(2) / 2)
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
     @test ft == 1.25
     @test nbk == 0
     @test nbW == 0
 
-    redirect!(lm, nlp.meta.x0, -2 * ones(T,2))
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)))
+    redirect!(lm, nlp.meta.x0, -2 * ones(2))
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t < 1
     @test nbk > 0
     @test nbW == 0
+
+    T=Float32
 
     nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, zeros(T,2))
     lm = LineModel(nlp, nlp.meta.x0, T.([1.7; 3.2]))

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -61,6 +61,38 @@
     @test nbW > 0
   end
 
+  @testset "Armijo-Goldstein" begin
+    nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(2))
+    lm = LineModel(nlp, nlp.meta.x0, -ones(2))
+    g = zeros(2)
+
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    @test t == 1
+    @test ft == 0.0
+    @test nbk == 0
+    @test nbW == 0
+
+    redirect!(lm, nlp.meta.x0, -ones(2) / 2)
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    @test t == 1
+    @test ft == 1.25
+    @test nbk == 0
+    @test nbW == 0
+
+    redirect!(lm, nlp.meta.x0, -2 * ones(2))
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    @test t < 1
+    @test nbk > 0
+    @test nbW == 0
+
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, zeros(2))
+    lm = LineModel(nlp, nlp.meta.x0, [1.7; 3.2])
+    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0); t = 2.)
+    @test t == 1.
+    @test nbk == 1
+    @test nbW == 0
+  end
+
   if VERSION ≥ v"1.6"
     @testset "Don't allocate" begin
       nlp = BROWNDEN()

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -67,7 +67,7 @@
 
     t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
-    @test ft == 0.0
+    @test ft == zero(T)
     @test nbk == 0
     @test nbG == 0
 
@@ -84,12 +84,12 @@
     @test nbk > 0
     @test nbG == 0
 
-    T=Float32
+    T = Float32
 
     nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, zeros(T,2))
     lm = LineModel(nlp, nlp.meta.x0, T.([1.7; 3.2]))
-    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(1.), τ₀ = T(0.1), τ₁ = T(0.2))
-    @test t < 1.
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0)), grad(lm, T(0)); t = T(1), τ₀ = T(0.1), τ₁ = T(0.2))
+    @test t < one(T)
     @test nbk == 4
     @test nbG == 10
 

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -65,6 +65,7 @@
     nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(2))
     lm = LineModel(nlp, nlp.meta.x0, -ones(2))
 
+    T = Float64
     t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
     @test ft == zero(T)

--- a/test/test_linesearch.jl
+++ b/test/test_linesearch.jl
@@ -64,35 +64,34 @@
   @testset "Armijo-Goldstein" begin
     nlp = ADNLPModel(x -> x[1]^2 + 4 * x[2]^2, ones(2))
     lm = LineModel(nlp, nlp.meta.x0, -ones(2))
-    g = zeros(2)
 
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
     @test ft == 0.0
     @test nbk == 0
-    @test nbW == 0
+    @test nbG == 0
 
     redirect!(lm, nlp.meta.x0, -ones(2) / 2)
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t == 1
     @test ft == 1.25
     @test nbk == 0
-    @test nbW == 0
+    @test nbG == 0
 
     redirect!(lm, nlp.meta.x0, -2 * ones(2))
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, 0.0), grad(lm, 0.0))
     @test t < 1
     @test nbk > 0
-    @test nbW == 0
+    @test nbG == 0
 
     T=Float32
 
     nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, zeros(T,2))
     lm = LineModel(nlp, nlp.meta.x0, T.([1.7; 3.2]))
-    t, ft, nbk, nbW = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(2.))
+    t, ft, nbk, nbG = armijo_goldstein(lm, obj(lm, T(0.0)), grad(lm, T(0.0)); t = T(2.))
     @test t == 1.
     @test nbk == 1
-    @test nbW == 0
+    @test nbG == 0
   end
 
   if VERSION ≥ v"1.6"
@@ -135,7 +134,7 @@
       end
 
       # armijo-goldstein
-      (t, ht, nbk, nbW) = armijo_goldstein(lm, h₀, slope)
+      (t, ht, nbk, nbG) = armijo_goldstein(lm, h₀, slope)
       al = @wrappedallocs armijo_goldstein(lm, h₀, slope)
       @test al == 0
 
@@ -144,7 +143,7 @@
       end
 
       for bk_max = 0:8
-        (t, ht, nbk, nbW) = armijo_goldstein(lm, h₀, slope, bk_max = bk_max)
+        (t, ht, nbk, nbG) = armijo_goldstein(lm, h₀, slope, bk_max = bk_max)
         al = armijo_goldstein_alloc(lm, h₀, slope, bk_max)
         @test al == 0
       end


### PR DESCRIPTION
Add a line-search solver for the Armijo-Goldstein conditions.
This is a direct implementation (M=0, no incumbent memory) of the method proposed in:
Cartis, C., Sampaio, P.R., Toint, P.L.: Worst-case evaluation complexity of non-monotone gradient-related algorithms for unconstrained optimization. Optimization 64(5), 1349–1361 (2015).